### PR TITLE
add subscripts to formula in detail page and browse page.

### DIFF
--- a/lib/SMMID/Controller/REST/SMID.pm
+++ b/lib/SMMID/Controller/REST/SMID.pm
@@ -49,7 +49,10 @@ sub browse :Chained('rest') PathPart('browse') Args(0) {
       if(!defined($r->curation_status()) || $r->curation_status() eq "unverified"){$cur_char = "<p style=\"color:red\">Unverified</p>";}
       elsif($r->curation_status() eq "review"){$cur_char = "<p style=\"color:blue\">Marked for Review</p>";}
 
-	push @data, ["<a href=\"/smid/".$r->compound_id()."\">".$r->smid_id()."</a>", $r->formula(), $r->molecular_weight(), $cur_char ];
+      my $formula_subscripts = $r->formula();
+      $formula_subscripts =~ s/(\d+)/\<sub\>$1\<\/sub\>/g;
+      
+	push @data, ["<a href=\"/smid/".$r->compound_id()."\">".$r->smid_id()."</a>", $formula_subscripts, $r->molecular_weight(), $cur_char ];
     }
 
     $c->stash->{rest} = { data => \@data };

--- a/root/js/source/entries/smid_detail.js
+++ b/root/js/source/entries/smid_detail.js
@@ -455,7 +455,9 @@ function populate_smid_data(compound_id) {
 		
 		
 		$('#formula_static_div').css('visibility', 'visible');
-		$('#formula_static_div').html(r.data.formula + '&nbsp;&nbsp;&nbsp;['+r.data.molecular_weight+' g/mol]');
+		var formula = r.data.formula;
+		var formula_subscripts = formula.replace(/(\d+)/g, '\<sub\>$1\<\/sub\>');
+		$('#formula_static_div').html(formula_subscripts + '&nbsp;&nbsp;&nbsp;['+r.data.molecular_weight+' g/mol]');
 		
 		$('#formula_input_div').hide();
 		$('#formula').val(r.data.formula);


### PR DESCRIPTION
In this PR, formulas in the detail page are shown with all numbers subscripted. This should be ok in most of the cases. Also, on the browse page, subscripts are added in the table. Maybe it should also be added to the curator page?