### PR TITLE
39 enable private smids

### DIFF
--- a/lib/SMIDDB/Result/Compound.pm
+++ b/lib/SMIDDB/Result/Compound.pm
@@ -100,7 +100,7 @@ __PACKAGE__->table("compound");
   is_nullable: 1
 
 =head2 molecular_weight
-   
+
    data_type: 'real'
    is_nullable: 0
 
@@ -108,6 +108,11 @@ __PACKAGE__->table("compound");
 
     data_type: varchar(255);
     is_nullable 1
+
+=head2 public_status
+
+    data_type: varchar(100);
+    is_nullable 0
 
 =cut
 
@@ -149,6 +154,7 @@ __PACKAGE__->add_columns(
     { data_type => "real", is_nullable => 0 },
     "doi",
     { data_type => "varchar", is_nullable => 1, size => 255 },
+  "public_status", {data_type => "varchar", is_nullable => 0, size => 100 },
 );
 
 =head1 PRIMARY KEY

--- a/lib/SMMID/Controller/REST/SMID.pm
+++ b/lib/SMMID/Controller/REST/SMID.pm
@@ -384,8 +384,13 @@ sub curate_smid :Chained('smid') PathPart('curate_smid') Args(0){
         $row->update($data);
       };
 
+      if ($@) {
+  	     $c->stash->{rest} = { error => "Sorry, an error occurred. ($@)" };
+  	      return;
+      }
+
       $c->stash->{rest} ={
-  	message => "Successfully updated the curation status of smid $smid_id"
+  	message => "Successfully curated smid $smid_id."
       };
 
     print STDERR "Smid ".$smid_id." curation status updated to $curation_status\n";
@@ -424,8 +429,13 @@ sub mark_for_review : Chained('smid') PathPart('mark_for_review') Args(0) {
       $row->update($data);
     };
 
+    if ($@) {
+       $c->stash->{rest} = { error => "Sorry, an error occurred. ($@)" };
+        return;
+    }
+
     $c->stash->{rest} ={
-  message => "Successfully updated the curation status of smid $smid_id"
+      message => "Successfully marked smid $smid_id for review."
     };
 
   print STDERR "Smid ".$smid_id." curation status updated to $curation_status\n";
@@ -470,8 +480,13 @@ sub mark_unverified :Chained('smid') PathPart('mark_unverified') Args(0){
         $row->update($data);
       };
 
+      if ($@) {
+  	     $c->stash->{rest} = { error => "Sorry, an error occurred. ($@)" };
+  	      return;
+      }
+
       $c->stash->{rest} ={
-  	message => "Successfully updated the curation status of smid $smid_id"
+  	     message => "Successfully marked smid $smid_id as unverified."
       };
 
     print STDERR "Smid ".$smid_id." curation status updated to $curation_status\n";
@@ -755,7 +770,7 @@ sub results : Chained('smid') PathPart('results') Args(0) {
         var delay = 1000;
         \$(this).hover(function(){
           timer=setTimeout(function(){
-            display_msms_visual(".$row->experiment_id().")
+            display_msms_visual_smid(".$row->experiment_id().")
           }, delay);
         }, function(){
           clearTimeout(timer);

--- a/lib/SMMID/Controller/REST/User.pm
+++ b/lib/SMMID/Controller/REST/User.pm
@@ -689,7 +689,7 @@ sub authored_smids :Chained('user') :PathPart('authored_smids') Args(0){
 
     next if (!$self->has_view_permission($c, $r));
 
-    push @data, ["<a href=\"/smid/".$r->compound_id()."\">".$r->smid_id()."</a>", $r->formula(), $r->molecular_weight(), $r->curation_status()];
+    push @data, ["<a href=\"/smid/".$r->compound_id()."\">".$r->smid_id()."</a>", $r->formula(), $r->molecular_weight(), $r->curation_status(), $r->public_status() ];
   }
   $c->stash->{rest} = {data => \@data};
 }

--- a/lib/SMMID/Controller/REST/User.pm
+++ b/lib/SMMID/Controller/REST/User.pm
@@ -686,6 +686,9 @@ sub authored_smids :Chained('user') :PathPart('authored_smids') Args(0){
   my $rs = $c->model("SMIDDB")->resultset("SMIDDB::Result::Compound")->search( {dbuser_id => $c->stash->{dbuser_id}} );
   my @data;
   while (my $r = $rs->next()){
+
+    next if (!$self->has_view_permission($c, $r));
+
     push @data, ["<a href=\"/smid/".$r->compound_id()."\">".$r->smid_id()."</a>", $r->formula(), $r->molecular_weight(), $r->curation_status()];
   }
   $c->stash->{rest} = {data => \@data};
@@ -704,12 +707,16 @@ sub authored_experiments :Chained('user') :PathPart('authored_experiments') Args
   my @data;
 
   while (my $r = $rs->next()){
+
+    next if (!$self->has_view_permission($c, $r->compound()));
+
     my $experiment_type;
     if ($r->experiment_type() eq "hplc_ms"){
       $experiment_type = "HPLC-MS";
     } else {
       $experiment_type = "MS/MS";
     }
+
     push @data, [$experiment_type, "<a href=\"/smid/".$r->compound_id()."\">".$r->compound()->smid_id()."</a>"];
   }
   $c->stash->{rest} = {data => \@data};
@@ -809,6 +816,20 @@ sub change_password :Chained('user') :PathPart('change_password') Args(0) {
   } else {
       $c->stash->{rest} = {success => 1};
   }
+}
+
+sub has_view_permission {
+  my $self = shift;
+  my $c = shift;
+  my $smid = shift;
+
+  if($smid->public_status() eq "public"){return 1;}
+
+  if(!$c->user() && $smid->public_status() eq "private"){return 0;}
+
+  if($smid->public_status() eq "private" && $c->user()->get_object()->dbuser_id() != $smid->dbuser_id() && $c->user()->get_object()->user_type() ne "curator"){return 0;}
+
+  return 1;
 }
 
 1;

--- a/mason/smid/curator.mas
+++ b/mason/smid/curator.mas
@@ -12,12 +12,10 @@
 
 <p id="no_login_text">You must be logged in as a curator to view this page. Please login.</p>
 <p>
-  <button id="new_account_button" type="button" class="btn btn-primary" style="display:none"><a style="color:white" href="/user/0/profile">Create a new user account</a></button>
+  <button id="new_account_button" type="button" class="btn btn-primary" onclick="location.href='/user/0/profile';" style="display:none"> Create a new user account </button>
   <p>&nbsp;</p>
   <p>&nbsp;</p>
-  <table id="browse_c_smid_data_div" style="width:100%" class="display">
-
-  </table>
+  <table id="browse_c_smid_data_div" style="width:100%" class="display"></table>
 </p>
 
 <script>

--- a/mason/smid/detail.mas
+++ b/mason/smid/detail.mas
@@ -29,7 +29,7 @@ $user_role => undef
 <!-- SMID input/output form -->
 
     <!-- form name="new_accessions_form" id="new_accessions_form" -->
-<table width="40%" id="detail_curation_table">
+<table width="60%" id="detail_curation_table">
   <tr>
    <td>
      <b><span id="curation_status" name="curation_status"></span></b>
@@ -39,11 +39,17 @@ $user_role => undef
      <button name="request_review_button" id="request_review_button"  class="btn btn-primary" disabled onclick="mark_smid_for_review(<% $compound_id %>)">Request a review of this SMID</button>
    </td>
 
-   <td>
-     <select id="curation_status_manipulate" name="curation_status_manipulate" onchange="change_curation_status(<% $compound_id %>, $('#curation_status_manipulate').val())">
+   <td id="change_curation_status">Change Curation Status:
+     <select id="curation_status_manipulate" name="curation_status_manipulate" onchange="change_curation_status(<% $compound_id %>, $('#curation_status_manipulate').val());">
        <option value="curated">Verified</option>
        <option value="review">Review</option>
        <option value="unverified">Unverified</option>
+     </select>
+   </td>
+   <td id="change_public_status">Change Visibility:
+     <select id="public_status_manipulate" name="public_status_manipulate" onchange="change_public_status(<% $compound_id %>, $('#public_status_manipulate').val());">
+       <option value="public">Public</option>
+       <option value="private">Private</option>
      </select>
    </td>
   </tr>
@@ -388,7 +394,7 @@ $user_role => undef
 	      <option>positive</option>
 	      <option>negative</option>
 	    </select>
-	    
+
 	    <!-- input type="input" class="form-control" id="hplc_ms_ionization_mode" placeholder="Ionization mode"> -->
 	  </div>
 	  <div class="form-group">
@@ -521,7 +527,7 @@ m/z        Intensity              Relative
 <div class="alert alert-danger" >
   <div><button class="btn btn-danger" id="delete_smid_button">Delete this SMID</button></div>
   <span>
-    This will eliminate the SMID from the database, along with structural, HPLC and spectral data. Deletion is permanent and cannot be undone.  
+    This will eliminate the SMID from the database, along with structural, HPLC and spectral data. Deletion is permanent and cannot be undone.
   </span>
 </div>
 %  }

--- a/mason/smid/detail.mas
+++ b/mason/smid/detail.mas
@@ -29,6 +29,10 @@ $user_role => undef
 <!-- SMID input/output form -->
 
     <!-- form name="new_accessions_form" id="new_accessions_form" -->
+
+
+% if ($compound_id != 0) {
+
 <table width="60%" id="detail_curation_table">
   <tr>
    <td>
@@ -56,6 +60,8 @@ $user_role => undef
 </table>
 
 <br></br>
+
+% }
 
       <center>
      <table width="90%">

--- a/mason/user.mas
+++ b/mason/user.mas
@@ -150,25 +150,11 @@ $sp_person_id
 <h2>Authored SMIDs</h2>
 
 <table id="user_authored_smids" class="display" style="width:90%">
-  <thead>
-    <tr>
-      <th>SMID ID</th>
-      <th>Formula</th>
-      <th>Molecular Weight</th>
-      <th>Curation Status</th>
-    </tr>
-  </thead>
 </table>
 
 <h2>Authored Experiments</h2>
 
 <table id="user_authored_experiments" class="display" style="width:90%">
-  <thead>
-    <tr>
-      <th>Experiment Type</th>
-      <th>Link to SMID</th>
-    </tr>
-  </thead>
 </table>
 
 <script>

--- a/mason/user.mas
+++ b/mason/user.mas
@@ -175,8 +175,6 @@ $sp_person_id
   $(document).ready(function(){
     var dbuser_id = <% $dbuser_id %>;
     populate_profile_data(dbuser_id);
-    populate_authored_smids(dbuser_id);
-    populate_authored_experiments(dbuser_id);
   });
 </script>
 

--- a/root/js/source/entries/browse.js
+++ b/root/js/source/entries/browse.js
@@ -22,7 +22,8 @@ function browse_html() {
         {title: "SMID ID"},
         {title: "Formula"},
         {title: "Molecular Weight"},
-        {title: "Curation Status"}
+        {title: "Curation Status"},
+        {title: "Visibility"}
       ]
     });
 	    }

--- a/root/js/source/entries/curator.js
+++ b/root/js/source/entries/curator.js
@@ -52,23 +52,28 @@ function curate_smid(compound_id){
       success: function(r){
         if (r.error){alert(r.error);}
         else {
-        $('#browse_c_smid_data_div').DataTable().ajax.reload();
+          $('#browse_c_smid_data_div').DataTable().ajax.reload();
+        }
       }
-    }
     });
   }
 
   function change_public_status(compound_id, new_status){
     $.ajax({
-      url: '/rest/smid/'+compound_id+'/change_public_status',
+      url: 'rest/smid/'+compound_id+'/change_public_status',
       data: {
-        'public_status' : new_status
+        'public_status' : new_status,
+      },
+      error: function(r){
+        alert("Sorry, an error occurred. "+r.responseText);
       },
       success: function(r){
-        if(r.error) {alert(r.error);}
+        if(r.error) {
+          alert(r.error);
+        }
         else{
           $('#browse_c_smid_data_div').DataTable().ajax.reload();
         }
       }
-    })
+    });
   }

--- a/root/js/source/entries/curator.js
+++ b/root/js/source/entries/curator.js
@@ -60,7 +60,7 @@ function curate_smid(compound_id){
 
   function change_public_status(compound_id, new_status){
     $.ajax({
-      url: 'rest/smid/'+compound_id+'/change_public_status',
+      url: '/rest/smid/'+compound_id+'/change_public_status',
       data: {
         'public_status' : new_status
       },

--- a/root/js/source/entries/curator.js
+++ b/root/js/source/entries/curator.js
@@ -15,9 +15,10 @@ function curator_html() {
           {title: "Compound ID"},
           {title: "SMID ID"},
           {title: "Formula"},
-          {title: "SMILES"},
           {title: "Action"},
-          {title: "Status"}
+          {title: "Visibility"},
+          {title: "Action"},
+          {title: "Curation Status"}
         ]
       });
 
@@ -55,4 +56,19 @@ function curate_smid(compound_id){
       }
     }
     });
+  }
+
+  function change_public_status(compound_id, new_status){
+    $.ajax({
+      url: 'rest/smid/'+compound_id+'/change_public_status',
+      data: {
+        'public_status' : new_status
+      },
+      success: function(r){
+        if(r.error) {alert(r.error);}
+        else{
+          $('#browse_c_smid_data_div').DataTable().ajax.reload();
+        }
+      }
+    })
   }

--- a/root/js/source/entries/smid_detail.js
+++ b/root/js/source/entries/smid_detail.js
@@ -411,7 +411,7 @@ function populate_smid_data(compound_id) {
 	error: function(r) { alert("An error occurred. "+r.responseText); },
 	success: function(r) {
 	    if (r.error) {
-		alert("No smid exists with id "+compound_id);
+		alert(r.error);
 		location.href='/browse/';
 		return;
 	    }
@@ -583,4 +583,22 @@ function display_msms_visual_smid(experiment_id){
   $('#msms_spectrum_visualizer').modal("show");
 
   display_msms_visual(experiment_id);
+}
+
+function change_public_status(compound_id, new_status){
+  $.ajax({
+    url: '/rest/smid/'+compound_id+'/change_public_status',
+    data: {
+      'public_status' : new_status
+    },
+    success: function(r){
+      if(r.error) {alert(r.error);}
+      else{
+        alert(r.message);
+      }
+    },
+    error: function(r){
+      alert("An error occurred."+r.responseText);
+    }
+  })
 }

--- a/root/js/source/entries/smid_detail.js
+++ b/root/js/source/entries/smid_detail.js
@@ -89,10 +89,10 @@ function make_fields_editable(compound_id) {
 		if (yes) {
 
 		    confirm("Please confirm that you want to delete this SMID.");
-		    if (yes) { 
+		    if (yes) {
 			var compound_id = $('#compound_id').html();
 			//alert('Compound ID to delete: '+compound_id);
-			
+
 			$.ajax( {
 			    url : '/rest/smid/'+compound_id+'/delete',
 			    error: function(e) { alert('Error... '+e.responseText); },
@@ -424,13 +424,22 @@ function populate_smid_data(compound_id) {
 		$('#organisms').val(r.data.organisms);
 		$('#organisms_input_div').css('visibility', 'hidden');
 
-		
+
 		has_login().then( function(p){
 		    if(p.user !== null && p.role == "curator"){
-			$('#curation_status_manipulate').prop('value', r.data.curation_status);
-		    } else {$('#curation_status_manipulate').prop('style', "display: none;");}
+			    $('#curation_status_manipulate').prop('value', r.data.curation_status);
+		    } else {
+          $('#change_curation_status').prop('style', "display: none;");
+          $('#curation_status_manipulate').prop('style', "display: none;");
+        }
+        if (p.user !== null && (p.user == r.data.dbuser_id || p.role == "curator")) {
+          $('#public_status_manipulate').prop('value', "public");
+        } else {
+          $('#change_public_status').prop('style', "display: none;");
+          $('#public_status_manipulate').prop('style', "display: none;");
+        }
 		});
-		
+
 		var curation_status_html = "";
 		if(r.data.curation_status == "curated"){
 		    curation_status_html = "Verified Entry";
@@ -444,24 +453,24 @@ function populate_smid_data(compound_id) {
 		    curation_status_html = "Marked for Review";
 		    $('#curation_status').prop('style',"color:blue; font-size:1.5em");
 		}
-		
+
 		$('#curation_status').html(curation_status_html);
-		
+
 		$('#doi').val(r.data.doi);
-		
+
 		if(r.data.curation_status == "" || r.data.curation_status == "unverified" || r.data.curation_status == "review"){
 		    $('#request_review_button').prop('style', "display:none");
 		} else {$('#request_review_button').prop('disabled', false);}
-		
-		
+
+
 		$('#formula_static_div').css('visibility', 'visible');
 		var formula = r.data.formula;
 		var formula_subscripts = formula.replace(/(\d+)/g, '\<sub\>$1\<\/sub\>');
 		$('#formula_static_div').html(formula_subscripts + '&nbsp;&nbsp;&nbsp;['+r.data.molecular_weight+' g/mol]');
-		
+
 		$('#formula_input_div').hide();
 		$('#formula').val(r.data.formula);
-		
+
 		$('#iupac_name_static_div').show();
 		$('#iupac_name_static_div').html(r.data.iupac_name);
 		$('#iupac_name').val(r.data.iupac_name);

--- a/root/js/source/entries/smid_detail.js
+++ b/root/js/source/entries/smid_detail.js
@@ -433,7 +433,7 @@ function populate_smid_data(compound_id) {
           $('#curation_status_manipulate').prop('style', "display: none;");
         }
         if (p.user !== null && (p.user == r.data.dbuser_id || p.role == "curator")) {
-          $('#public_status_manipulate').prop('value', "public");
+          $('#public_status_manipulate').prop('value', r.data.public_status);
         } else {
           $('#change_public_status').prop('style', "display: none;");
           $('#public_status_manipulate').prop('style', "display: none;");

--- a/root/js/source/entries/smid_detail.js
+++ b/root/js/source/entries/smid_detail.js
@@ -532,6 +532,7 @@ function mark_smid_for_review(compound_id){
     success: function(r){
       if (r.error){alert(r.error);}
       else {
+        alert(r.message);
         $('#curation_status').html("Marked for Review");
         $('#curation_status').prop('style',"color:blue; font-size:1.5em");
       }
@@ -548,6 +549,7 @@ function mark_smid_unverified(compound_id){
     success: function(r){
       if (r.error){alert(r.error);}
       else {
+        alert(r.message);
         $('#curation_status').html("Unverified Entry");
         $('#curation_status').prop('style',"color:red; font-size:1.5em");
       }
@@ -564,6 +566,7 @@ function curate_smid(compound_id){
     success: function(r){
       if (r.error){alert(r.error);}
       else {
+        alert(r.message);
         $('#curation_status').html("Verified Entry");
         $('#curation_status').prop('style',"color:green; font-size:1.5em");
       }

--- a/root/js/source/entries/user_profile.js
+++ b/root/js/source/entries/user_profile.js
@@ -41,7 +41,8 @@ function populate_authored_smids(user_id){
       {title: "SMID ID"},
       {title: "Formula"},
       {title: "Molecular Weight"},
-      {title: "Curation Status"}
+      {title: "Curation Status"},
+      {title: "Visibility"}
     ]
   });
 

--- a/root/js/source/entries/user_profile.js
+++ b/root/js/source/entries/user_profile.js
@@ -3,7 +3,10 @@ function populate_profile_data(user_id){
   $.ajax({
     url: '/rest/user/'+user_id+'/profile',
     success: function(r){
-      if(r.error){alert(r.error);}
+      if(r.error){
+        alert(r.error);
+        window.history.back();
+      }
       else{
         $('#user_name').html(r.data.full_name);
         $('#user_email').html(r.data.email_address);
@@ -16,6 +19,9 @@ function populate_profile_data(user_id){
         $('#edit_email').val(r.data.email_address);
         $('#edit_organization').val(r.data.organization);
         $('#edit_username').val(r.data.username);
+
+        populate_authored_smids(user_id);
+        populate_authored_experiments(user_id);
       }
     },
     error: function(r){


### PR DESCRIPTION
Includes first features of new public_status field.
-Smids can be hidden from other viewers. These smids are denoted as "private". Visible smids are denoted as "public"
-Browse tab has a custom display for each viewer, showing only smids they have permission to view
-User profiles hide private smids from unauthorized users
-Function has_view_permission in controller determines if user has permission to view a smid
-Toolbar at top of smid detail page is hidden when making a new smid; new smids are always stored as private and unverified