### PR TITLE
Addition of group-related tables and dbpatches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,7 @@ COPY smmid_local.conf.docker /home/production/SMMID/smmid_local.conf
 
 WORKDIR /home/production/SMMID
 
-RUN git checkout relational_smid
-
-ENV PERL5LIB=/home/production/SMMID/lib:/home/production/local-lib/lib/perl5
+ENV PERL5LIB=/home/production/SMMID/lib:/home/production/local-lib/lib/perl5:.
 ENV CATALYST_HOME=/home/production/SMMID
 
 ENTRYPOINT bash /entrypoint.sh

--- a/build.sh
+++ b/build.sh
@@ -24,5 +24,5 @@ cpanm -L /home/production/local-lib Chemistry::File::SMILES
 cpanm -L /home/production/local-lib Image::Size
 cpanm -L /home/production/local-lib YAML
 cpanm -L /home/production/local-lib Test::Selenium::Remote::Driver
-
+cpanm -L /home/production/local-lib MooseX::Runnable
 

--- a/dbpatches/0000/InstallDbPatchTables.pm
+++ b/dbpatches/0000/InstallDbPatchTables.pm
@@ -1,0 +1,26 @@
+
+package InstallDbPatchTables;
+
+use Moose;
+use Dbpatch::PatchRoot;
+
+extends 'Dbpatch::PatchRoot';
+
+sub init_patch {
+    my $self = shift;
+
+    $self->name('InstallDbPatchTables');
+    $self->description('Install the dbpatch tables.');
+
+}
+
+sub patch {
+    my $self = shift;
+
+    print STDERR "HELLO WORLD!\n";
+    # do nothing, the db patch tables should be installed automatically
+    # if not already installed.
+
+}
+
+1;

--- a/dbpatches/0001/AddGroupTables.pm
+++ b/dbpatches/0001/AddGroupTables.pm
@@ -6,15 +6,28 @@ use Moose;
 extends 'Dbpatch::PatchRoot';
 
 sub init_patch {
+    my $self = shift;
+    $self->name('AddGroupTables');
+    $self->description('Adds dbgroup etc.');
+
 }
 
 sub patch {
     my $self = shift;
 
-    $self->dbh()->do("create table dbgroup ( dbgroup_id serial primary key, name varchar(100), description text)");
+    eval { 
+	$self->dbh()->do("create table dbgroup ( dbgroup_id serial primary key, name varchar(100), description text)");
+    };
+    if ($@) { print STDERR "ERROR: $@\n"; }
 
-    $self->dbh()->do("create table dbuser_dbgroup ( dbuser_dbgroup_id serial primary key, dbuser_id references dbuser, dbgroup_id references dbgroup)");
+    eval { 
+	$self->dbh()->do("create table dbuser_dbgroup ( dbuser_dbgroup_id serial primary key, dbuser_id bigint references dbuser, dbgroup_id bigint references dbgroup)");
+    };
+    if ($@) { print STDERR "ERROR: $@\n"; }
 
-    $self->dbh()->do("alter table compound add column dbgroup_id bigint references dbgroup");
-    
+    eval { 
+	$self->dbh()->do("alter table compound add column dbgroup_id bigint references dbgroup");
+    };
+    if ($@) { print STDERR "ERROR: $@\n"; }
+
 }

--- a/dbpatches/0001/AddGroupTables.pm
+++ b/dbpatches/0001/AddGroupTables.pm
@@ -1,0 +1,20 @@
+
+package AddGroupTables;
+
+use Moose;
+
+extends 'Dbpatch::PatchRoot';
+
+sub init_patch {
+}
+
+sub patch {
+    my $self = shift;
+
+    $self->dbh()->do("create table dbgroup ( dbgroup_id serial primary key, name varchar(100), description text)");
+
+    $self->dbh()->do("create table dbuser_dbgroup ( dbuser_dbgroup_id serial primary key, dbuser_id references dbuser, dbgroup_id references dbgroup)");
+
+    $self->dbh()->do("alter table compound add column dbgroup_id bigint references dbgroup");
+    
+}

--- a/dbpatches/DbpatchTemplate.pm
+++ b/dbpatches/DbpatchTemplate.pm
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+
+
+=head1 NAME
+
+ SampleDbpatchMoose.pm
+
+=head1 SYNOPSIS
+
+mx-run ThisPackageName [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+
+This is a test dummy patch.
+This subclass uses L<Moose>. The parent class uses L<MooseX::Runnable>
+
+=head1 AUTHOR
+
+ Naama Menda<nm249@cornell.edu>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2010 Boyce Thompson Institute for Plant Research
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+
+package DbpatchTemplate;
+
+use Moose;
+extends 'Dbpatch';
+
+
+sub init_patch { 
+    my $self = shift;
+
+    $self->description('Use DbpatchTemplate to implement new patches.' );
+    $self->prepreq( [ ] ); # list the prerequisite patches here. (not yet supported for smid-db)
+}
+
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " .   $self->name . ".\n\nDescription:\n  ".  $self->description . ".\n\nExecuted by:\n " .  $self->username . " .";
+
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    $self->dbh->do(<<EOSQL);
+--do your SQL here
+--
+SELECT * from public.stock;
+
+EOSQL
+
+print "You're done!\n";
+}
+
+
+####
+1; #
+####

--- a/lib/Dbpatch.pm
+++ b/lib/Dbpatch.pm
@@ -1,0 +1,12 @@
+use utf8;
+
+package Dbpatch;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+use base 'DBIx::Class::Schema';
+
+__PACKAGE__->load_namespaces;
+
+1;

--- a/lib/Dbpatch/PatchRoot.pm
+++ b/lib/Dbpatch/PatchRoot.pm
@@ -1,0 +1,330 @@
+
+package Dbpatch::PatchRoot;
+
+use Moose;
+
+with 'MooseX::Getopt';
+with 'MooseX::Runnable';
+
+use DBI;
+use SMIDDB;
+use Dbpatch;
+use Text::Table;
+
+has 'dbhost' => (
+    isa => 'Str',
+    is => 'rw',
+    required      => 0,
+    traits        => ['Getopt'],
+    cmd_aliases   => 'H',
+    documentation => 'required, database host',
+    default => 'smid_db_postgres',
+    );
+
+has 'dbname' => (
+    isa => 'Str',
+    is => 'rw',
+    required      => 0,
+    traits        => ['Getopt'],
+    cmd_aliases   => 'D',
+    documentation => 'required, database name',
+    default => 'smid_db',
+    );
+
+has 'dbpass' => (
+    isa => 'Str',
+    is => 'rw',
+    required      => 0,
+    traits        => ['Getopt'],
+    cmd_aliases   => 'p',
+    documentation => 'required, database password',
+    default => 'postgres',
+    );
+
+has 'dbuser' => (
+    isa => 'Str',
+    is => 'rw',
+    required      => 0,
+    default => 'postgres', 
+    traits        => ['Getopt'],
+    cmd_aliases   => 'x',
+    documentation => 'required, database host',
+    );
+
+has 'username' => (
+    isa => 'Str',
+    is => 'rw',
+    required      => 0,
+    traits        => ['Getopt'],
+    cmd_aliases   => 'u',
+    documentation => 'required, database host',
+    );
+
+has "prereq" => (
+    is       => 'rw',
+    isa      => 'ArrayRef',
+    required => 0,
+    traits   => ['NoGetopt'],
+    default  => sub { [] }
+);
+
+has 'force' => (
+    is          => 'rw',
+    isa         => 'Bool',
+    required    => 0,
+    default     => 0,
+    traits      => ['Getopt'],
+    cmd_aliases => 'F',
+    documentation =>
+      'force apply, ignoring prereqs and possible duplicate application',
+);
+
+has 'test_mode' => (
+    is          => 'rw',
+    isa         => 'Bool',
+    required    => 0,
+    default     => 0,
+    traits      => ['Getopt'],
+    cmd_aliases => 't',
+    documentation =>
+      'Test run. Rollback the transaction.',
+);
+
+has 'name' => (    #name of the dbpatch
+    is     => 'rw',
+    isa    => 'Str',
+		   default => sub { return __PACKAGE__; }
+		   
+    );
+
+has 'description' => (
+    is => 'rw',
+    isa => 'Str',
+    );
+
+has 'dbh' => (
+    is => 'rw',
+    isa => 'Ref',
+    );
+
+has 'schema' => (
+    is => 'rw',
+    isa => 'Ref',
+    );
+
+has 'trial_mode' => (
+    is => 'rw',
+    isa => 'Bool',
+    );
+
+has 'list' => (
+    is => 'rw',
+    isa => 'Bool',
+    required => 0,
+    traits      => ['Getopt'],
+    default => 0,
+    cmd_aliases => 'l',
+    documentation => 'Test run. Rollback the transaction.',
+    );
+
+has 'list_files' => (
+    is => 'rw',
+    isa => 'Bool',
+    required => 0,
+    traits      => ['Getopt'],
+    default => 0,
+    cmd_aliases => 'f',
+    documentation => 'List available dbpatch files.',
+    );
+
+has 'update' => (
+    is => 'rw',
+    isa => 'Bool',
+    required => 0,
+    traits      => ['Getopt'],
+    default => 0,
+    cmd_aliases => 'r',
+    documentation => 'List available dbpatch files.',
+    );
+    
+sub init_patch {
+    print STDERR "init_patch() needs to be implemented in the subclass.\n";
+}
+
+sub patch {
+    print STDERR "patch() needs to be implemetned in the subclass.\n";
+}
+
+
+sub run {
+    my $self = shift;
+
+    print STDERR "Connecting to database ".$self->dbname()." on host ".$self->dbhost()."...\n";
+    
+    $self->init_patch;  #override this in the child class
+
+    my $dbh =  DBI->connect('dbi:Pg:host='.$self->dbhost().";database=".$self->dbname(), 
+			    $self->dbuser(),
+			    $self->dbpass(),
+			    { AutoCommit => 0, RaiseError => 1}
+        );
+
+    $dbh->{AutoCommit} = 1;
+
+    $self->dbh($dbh);
+
+    my $dbpatch_schema = Dbpatch->connect( sub { return $dbh; } );
+    $self->schema($dbpatch_schema);
+
+    print STDERR "LIST : ".$self->list()."\n";
+    if ($self->list()) {
+	print STDERR "LIST HERE...\n";
+	$self->list_installed_dbpatches();
+	exit();
+    }
+
+    if ($self->list_files()) {
+	my @dbpatches = get_dbpatch_files();
+	print "AVAILABLE DBPATCH FILES:\n";
+	print "------------------------\n";
+	print join("\n", @dbpatches)."\n";
+	exit();
+    }
+
+     if ($self->update()) {
+	$self->run_all_patches();
+	exit();
+    }
+
+
+    
+    my $rs;
+    eval { 
+	$rs = $dbpatch_schema->resultset('Dbpatch')->search( { name => $self->name() });
+	if ($rs->count > 0) {
+	    die "Dbpatch has already been run in ".$rs->next()->run_timestamp()."\n";
+	}
+    };
+
+    
+    
+    if ($@ =~ m/does not exist/) {
+	print STDERR "$@ ... Inserting dbpatch table...\n";
+	$dbh->do("CREATE TABLE dbpatch (dbpatch_id serial primary key, dbuser_id bigint references dbuser, name varchar(100), description text, prereqs text, run_timestamp timestamp without time zone not null default now() )");
+	###$dbh->do("GRANT USAGE ON TABLE dbpatch");
+    }
+    else {
+	die "Can't continue: $@\n";
+    }
+
+
+    
+    
+    #CREATE A METADATA OBJECT and a new metadata_id in the database for this data
+
+    ## patch method defined in subclass :-)
+    #
+    my $error = $self->patch;
+    if ($error ne '1') {
+        print "Failed! Rolling back! \n $error \n ";
+        exit();
+    } elsif ( $self->trial_mode) {
+        print "Trial mode! Not storing new metadata and dbversion rows\n";
+    } else {
+	$dbpatch_schema->resultset("Dbpatch::Result::Dbpatch")->create(
+	    {
+		name => $self->name(),
+		description => $self->description(),
+	    });
+    }
+}
+
+
+sub list_installed_dbpatches {
+    my $self = shift;
+    print STDERR "LIST DB PATCHES\n";
+
+    my $tb = Text::Table->new( "Name",  \' | ',  "Description",  \' | ', "Run_date",  \' | ', "Operator", \' |');
+
+    my %not_installed_files = ();
+    my @available_dbpatch_files  = get_dbpatch_files();
+    foreach my $dpf (@available_dbpatch_files ) {
+	$not_installed_files{$dpf} = 1;
+    }
+
+    my $rs = $self->schema()->resultset('Dbpatch')->search( { });
+    my @lines;
+    while (my $row = $rs->next()) {
+	$not_installed_files{$row->name()} = 0;
+	$tb->add( $row->name, $row->description,  $row->run_timestamp,  $row->dbuser_id );
+	
+
+    }
+
+    foreach my $k (%not_installed_files) {
+	if ($not_installed_files{$k} == 1) {
+	    $tb->add($k, "-", "-", "-" );
+	}
+    }
+    my $rule = $tb->rule('-','+');
+    
+    print $rule, $tb->title(), $rule, $tb->body(), $rule."\n";
+}
+
+sub get_dbpatch_files {
+    my $self = shift;
+    my $full_paths = shift;
+    
+    my @dbpatches = glob 'dbpatches/*/*.pm';
+
+    foreach my $dbp (@dbpatches) {
+	if (! $full_paths ) { $dbp =~ s/.*\/(.*?).pm/$1/; }
+    }
+    return @dbpatches;
+}
+
+sub run_all_patches {
+    my $self = shift;
+
+    # determine the uninstalled files
+    #
+    my %not_installed_files;
+    my %not_installed_paths;
+    my @available_dbpatch_files  = $self->get_dbpatch_files(1);
+    foreach my $dbp (@available_dbpatch_files ) {
+	print STDERR "PATH = $dbp\n";
+	my $path = $dbp;
+	$dbp =~ s/.*\/(.*?).pm/$1/;
+	print STDERR "FILE = $dbp\n";
+	my $file = $dbp;
+
+	$not_installed_files{$file} = $path;
+    }
+
+    my $rs = $self->schema()->resultset('Dbpatch')->search( { });
+    my @lines;
+    while (my $row = $rs->next()) {
+	if ($not_installed_files{$row->name()}) {
+	    delete($not_installed_files{$row->name()});
+	}
+    }
+
+    foreach my $k (%not_installed_files) {
+	require($not_installed_files{$k});
+	print STDERR "Running $k...\n";
+	my $patch = $k->new();
+	$patch->dbname($self->dbname());
+	$patch->dbhost($self->dbhost());
+	$patch->dbpass($self->dbpass());
+	$patch->dbuser($self->dbuser());
+
+	print STDERR "Running $k as ".$patch->dbuser()."\n";
+	$patch->dbh($self->dbh());
+	$patch->schema($self->schema());
+	$patch->patch();
+    }
+} 
+
+    
+1;    
+    

--- a/lib/Dbpatch/Result/Dbpatch.pm
+++ b/lib/Dbpatch/Result/Dbpatch.pm
@@ -1,0 +1,111 @@
+
+=head1 NAME
+
+Dbpatch
+
+=cut
+
+package Dbpatch::Result::Dbpatch;
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 TABLE: C<dbpatch>
+
+=cut
+
+__PACKAGE__->table("dbpatch");
+
+=head1 ACCESSORS
+
+=head2 dbpatch_id
+
+  data_type: 'integer'
+  is_auto_increment: 1
+  is_nullable: 0
+  sequence: 'dbpatch_dbpatch_id_seq'
+
+=head2 name
+
+  data_type: 'text'
+  is_nullable: 1
+  original: {data_type => "varchar"}
+
+=head2 run_timestamp
+
+  data_type: 'timestamp'
+  is_nullable: 1
+
+=head2 dbuser_id
+
+  data_type: 'bigint'
+  is_foreign_key: 1
+  is_nullable: 0
+
+=head2 description
+
+  
+=cut
+
+__PACKAGE__->add_columns(
+  "dbpatch_id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "dbpatch_dbpatch_id_seq",
+  },
+  "name",
+  {
+    data_type   => "text",
+    is_nullable => 1,
+    original    => { data_type => "varchar" },
+  },
+  "run_timestamp",
+  { data_type => "timestamp", is_nullable => 1 },
+  "dbuser_id",
+    { data_type => "bigint", is_foreign_key => 1, is_nullable => 0 },
+
+    "description",
+    { data_type => "varchar" }
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</dbpatch_id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("dbpatch_id");
+
+=head1 RELATIONS
+
+=head2 dbuser
+
+Type: belongs_to
+
+Related object: L<SMIDDB::Result::Dbuser>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "dbuser",
+  "SMIDDB::Result::Dbuser",
+  { dbuser_id => "dbuser_id" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-03-07 20:24:54
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:pXp8jVCiydZ7wzDhlbDwAw
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+
+1;

--- a/lib/SMIDDB/Result/Compound.pm
+++ b/lib/SMIDDB/Result/Compound.pm
@@ -30,6 +30,320 @@ __PACKAGE__->table("compound");
   is_nullable: 0
   sequence: 'compound_compound_id_seq'
 
+=head2 organisms
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 smid_id
+
+  data_type: 'varchar'
+  is_nullable: 0
+  size: 100
+
+=head2 curation_status
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 100
+
+=head2 dbuser_id
+
+  data_type: 'bigint'
+  is_foreign_key: 1
+  is_nullable: 1
+
+=head2 curator_id
+
+  data_type: 'bigint'
+  is_foreign_key: 1
+  is_nullable: 1
+
+=head2 last_curated_time
+
+  data_type: 'timestamp'
+  is_nullable: 1
+
+=head2 create_date
+
+  data_type: 'timestamp'
+  is_nullable: 1
+
+=head2 last_modified_date
+
+  data_type: 'timestamp'
+  is_nullable: 1
+
+=head2 iupac_name
+
+  data_type: 'text'
+  is_nullable: 0
+
+=head2 synonyms
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 description
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 smiles
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 formula
+
+  data_type: 'text'
+  is_nullable: 1
+
+=head2 molecular_weight
+
+  data_type: 'real'
+  is_nullable: 1
+
+=head2 doi
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 255
+
+=head2 public_status
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 100
+
+=head2 dbgroup_id
+
+  data_type: 'bigint'
+  is_foreign_key: 1
+  is_nullable: 1
+
+=cut
+
+__PACKAGE__->add_columns(
+  "compound_id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "compound_compound_id_seq",
+  },
+  "organisms",
+  { data_type => "text", is_nullable => 1 },
+  "smid_id",
+  { data_type => "varchar", is_nullable => 0, size => 100 },
+  "curation_status",
+  { data_type => "varchar", is_nullable => 1, size => 100 },
+  "dbuser_id",
+  { data_type => "bigint", is_foreign_key => 1, is_nullable => 1 },
+  "curator_id",
+  { data_type => "bigint", is_foreign_key => 1, is_nullable => 1 },
+  "last_curated_time",
+  { data_type => "timestamp", is_nullable => 1 },
+  "create_date",
+  { data_type => "timestamp", is_nullable => 1 },
+  "last_modified_date",
+  { data_type => "timestamp", is_nullable => 1 },
+  "iupac_name",
+  { data_type => "text", is_nullable => 0 },
+  "synonyms",
+  { data_type => "text", is_nullable => 1 },
+  "description",
+  { data_type => "text", is_nullable => 1 },
+  "smiles",
+  { data_type => "text", is_nullable => 1 },
+  "formula",
+  { data_type => "text", is_nullable => 1 },
+  "molecular_weight",
+  { data_type => "real", is_nullable => 1 },
+  "doi",
+  { data_type => "varchar", is_nullable => 1, size => 255 },
+  "public_status",
+  { data_type => "varchar", is_nullable => 1, size => 100 },
+  "dbgroup_id",
+  { data_type => "bigint", is_foreign_key => 1, is_nullable => 1 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</compound_id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("compound_id");
+
+=head1 UNIQUE CONSTRAINTS
+
+=head2 C<compound_smid_id_key>
+
+=over 4
+
+=item * L</smid_id>
+
+=back
+
+=cut
+
+__PACKAGE__->add_unique_constraint("compound_smid_id_key", ["smid_id"]);
+
+=head1 RELATIONS
+
+=head2 compound_dbxrefs
+
+Type: has_many
+
+Related object: L<SMIDDB::Result::CompoundDbxref>
+
+=cut
+
+__PACKAGE__->has_many(
+  "compound_dbxrefs",
+  "SMIDDB::Result::CompoundDbxref",
+  { "foreign.compound_id" => "self.compound_id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 compound_images
+
+Type: has_many
+
+Related object: L<SMIDDB::Result::CompoundImage>
+
+=cut
+
+__PACKAGE__->has_many(
+  "compound_images",
+  "SMIDDB::Result::CompoundImage",
+  { "foreign.compound_id" => "self.compound_id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 curator
+
+Type: belongs_to
+
+Related object: L<SMIDDB::Result::Dbuser>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "curator",
+  "SMIDDB::Result::Dbuser",
+  { dbuser_id => "curator_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+
+=head2 dbgroup
+
+Type: belongs_to
+
+Related object: L<SMIDDB::Result::Dbgroup>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "dbgroup",
+  "SMIDDB::Result::Dbgroup",
+  { group_id => "dbgroup_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+
+=head2 dbuser
+
+Type: belongs_to
+
+Related object: L<SMIDDB::Result::Dbuser>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "dbuser",
+  "SMIDDB::Result::Dbuser",
+  { dbuser_id => "dbuser_id" },
+  {
+    is_deferrable => 0,
+    join_type     => "LEFT",
+    on_delete     => "NO ACTION",
+    on_update     => "NO ACTION",
+  },
+);
+
+=head2 experiments
+
+Type: has_many
+
+Related object: L<SMIDDB::Result::Experiment>
+
+=cut
+
+__PACKAGE__->has_many(
+  "experiments",
+  "SMIDDB::Result::Experiment",
+  { "foreign.compound_id" => "self.compound_id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-03-07 20:24:54
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:sTn7UlysP+RMeu76xozAVw
+# These lines were loaded from '/home/production/SMMID/lib/SMIDDB/Result/Compound.pm' found in @INC.
+# They are now part of the custom portion of this file
+# for you to hand-edit.  If you do not either delete
+# this section or remove that file from @INC, this section
+# will be repeated redundantly when you re-create this
+# file again via Loader!  See skip_load_external to disable
+# this feature.
+
+use utf8;
+package SMIDDB::Result::Compound;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+SMIDDB::Result::Compound
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 TABLE: C<compound>
+
+=cut
+
+__PACKAGE__->table("compound");
+
+=head1 ACCESSORS
+
+=head2 compound_id
+
+  data_type: 'integer'
+  is_auto_increment: 1
+  is_nullable: 0
+  sequence: 'compound_compound_id_seq'
+
 =head2 formula
 
   data_type: 'text'
@@ -297,6 +611,11 @@ __PACKAGE__->has_many(
 
 # Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-09-04 17:41:53
 # DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:+HeVslA836wmXQLRmozVVQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;
+# End of lines loaded from '/home/production/SMMID/lib/SMIDDB/Result/Compound.pm'
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/SMIDDB/Result/Dbgroup.pm
+++ b/lib/SMIDDB/Result/Dbgroup.pm
@@ -1,0 +1,110 @@
+use utf8;
+package SMIDDB::Result::Dbgroup;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+SMIDDB::Result::Dbgroup
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 TABLE: C<dbgroup>
+
+=cut
+
+__PACKAGE__->table("dbgroup");
+
+=head1 ACCESSORS
+
+=head2 group_id
+
+  data_type: 'integer'
+  is_auto_increment: 1
+  is_nullable: 0
+  sequence: 'dbgroup_group_id_seq'
+
+=head2 name
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 100
+
+=head2 description
+
+  data_type: 'text'
+  is_nullable: 1
+
+=cut
+
+__PACKAGE__->add_columns(
+  "group_id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "dbgroup_group_id_seq",
+  },
+  "name",
+  { data_type => "varchar", is_nullable => 1, size => 100 },
+  "description",
+  { data_type => "text", is_nullable => 1 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</group_id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("group_id");
+
+=head1 RELATIONS
+
+=head2 compounds
+
+Type: has_many
+
+Related object: L<SMIDDB::Result::Compound>
+
+=cut
+
+__PACKAGE__->has_many(
+  "compounds",
+  "SMIDDB::Result::Compound",
+  { "foreign.dbgroup_id" => "self.group_id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+=head2 dbuser_dbgroups
+
+Type: has_many
+
+Related object: L<SMIDDB::Result::DbuserDbgroup>
+
+=cut
+
+__PACKAGE__->has_many(
+  "dbuser_dbgroups",
+  "SMIDDB::Result::DbuserDbgroup",
+  { "foreign.dbgroup" => "self.group_id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-03-07 20:24:54
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:GWVxrfGjWvMAJhywy7FtdQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/lib/SMIDDB/Result/DbuserDbgroup.pm
+++ b/lib/SMIDDB/Result/DbuserDbgroup.pm
@@ -1,0 +1,111 @@
+use utf8;
+package SMIDDB::Result::DbuserDbgroup;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+SMIDDB::Result::DbuserDbgroup
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 TABLE: C<dbuser_dbgroup>
+
+=cut
+
+__PACKAGE__->table("dbuser_dbgroup");
+
+=head1 ACCESSORS
+
+=head2 dbuser_dbgroup_id
+
+  data_type: 'integer'
+  is_auto_increment: 1
+  is_nullable: 0
+  sequence: 'dbuser_dbgroup_dbuser_dbgroup_id_seq'
+
+=head2 dbuser
+
+  data_type: 'bigint'
+  is_foreign_key: 1
+  is_nullable: 0
+
+=head2 dbgroup
+
+  data_type: 'bigint'
+  is_foreign_key: 1
+  is_nullable: 0
+
+=cut
+
+__PACKAGE__->add_columns(
+  "dbuser_dbgroup_id",
+  {
+    data_type         => "integer",
+    is_auto_increment => 1,
+    is_nullable       => 0,
+    sequence          => "dbuser_dbgroup_dbuser_dbgroup_id_seq",
+  },
+  "dbuser",
+  { data_type => "bigint", is_foreign_key => 1, is_nullable => 0 },
+  "dbgroup",
+  { data_type => "bigint", is_foreign_key => 1, is_nullable => 0 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</dbuser_dbgroup_id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("dbuser_dbgroup_id");
+
+=head1 RELATIONS
+
+=head2 dbgroup
+
+Type: belongs_to
+
+Related object: L<SMIDDB::Result::Dbgroup>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "dbgroup",
+  "SMIDDB::Result::Dbgroup",
+  { group_id => "dbgroup" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+=head2 dbuser
+
+Type: belongs_to
+
+Related object: L<SMIDDB::Result::Dbuser>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "dbuser",
+  "SMIDDB::Result::Dbuser",
+  { dbuser_id => "dbuser" },
+  { is_deferrable => 0, on_delete => "NO ACTION", on_update => "NO ACTION" },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-03-07 20:24:54
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:cTStEQjKUMRImFUgzRvmYA
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/script/dbpatch.pl
+++ b/script/dbpatch.pl
@@ -1,3 +1,4 @@
+#!/usr/bin/perl
 
 use strict;
 

--- a/script/dbpatch.pl
+++ b/script/dbpatch.pl
@@ -1,0 +1,16 @@
+
+use strict;
+
+package dbpatch;
+
+use Moose;
+
+extends 'Dbpatch::PatchRoot';
+
+my $dbpatch = dbpatch->new_with_options();
+
+$dbpatch->run();
+
+
+
+

--- a/t/test_fixture.pl
+++ b/t/test_fixture.pl
@@ -85,7 +85,7 @@ my $dsn = $config->{'Model::SMIDDB'}->{connect_info}->{dsn};
 my $dbuser = $config->{'Model::SMIDDB'}->{connect_info}->{user};
 my $db_user_password = $config->{'Model::SMIDDB'}->{connect_info}->{password};
 #This line needs to be changed for local machine
-my $db_postgres_password = 'DebianBox**'; #$config->{'Model::SMIDDB'}->{connect_info}->{password};
+my $db_postgres_password = $config->{'Model::SMIDDB'}->{connect_info}->{password};
 my $dbhost;
 if ($dsn =~ m/host=(.*?)\;/) {
     $dbhost = $1;
@@ -150,6 +150,8 @@ open(my $NEWCONF, ">", "smmid_fixture.yml") || die "Can't open smmid_fixture.con
 print $NEWCONF $new_conf;
 close($NEWCONF);
 
+print STDERR "Running dbpatches...\n";
+system("script/dbpatch.pl -H $dbhost -D $dbname -p $db_postgres_password --update");
 my $schema = SMIDDB->connect($test_dsn.";user=postgres;password=$db_postgres_password");
 
 # add basic users


### PR DESCRIPTION
adds dbpatches, dbpatches for dbgroup related tables, DBIx::Classes for new the new tables, minor edits in Dockerfile (addition of MooseX::Runnable and changes to $PERL5LIB), removal of hard-coded pw in test_fixture.pl, which now also runs the db patches before running the tests.